### PR TITLE
Add support to new goth versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ config :waffle,
 ```
 
 In order to be compatible with newer Goth versions, add the following functions
-to your definition module:
+to the definition modules:
 
 ```elixir
 # Specify the Goth module to authenticate in GCP.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ config :waffle,
   storage_dir: "uploads/waffle"
 ```
 
-Finally, in order to be compatible with newer Goth versions, you will need to
+Finally, in order to be compatible with Goth 1.2 and above, you will need to
 specify the adapter and the service account path in the definition module:
 
 ```elixir

--- a/README.md
+++ b/README.md
@@ -60,12 +60,25 @@ config :waffle,
   storage_dir: "uploads/waffle"
 ```
 
+Also, add the following functions to your definition module:
+
+```elixir
+# Specify the Goth module to authenticate in GCP.
+def goth_module do
+  MyApp.Goth.Storage
+end
+
+# Defines the service account file to be used to sign the urls.
+def service_account_path do
+  Application.fetch_env!(:my_app, :gcp_storage)
+  |> Keyword.get(:service_account_path)
+end
+```
+
 **Note**: a valid bucket name is a required config. This can either be a
 hard-coded string (e.g. `"gcs-bucket"`) or a system env tuple (e.g.
 `{:system, "WAFFLE_BUCKET"}`). You can also override this in your definition
 module (e.g. `def bucket(), do: "my-bucket"`).
-
-Authentication is done through Goth which requires credentials (https://github.com/peburrows/goth#installation).
 
 ## URL Signing
 

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ config :waffle,
   storage_dir: "uploads/waffle"
 ```
 
-In order to be compatible with newer Goth versions, add the following functions
-to the definition modules:
+Finally, in order to be compatible with newer Goth versions, you will need to
+specify the adapter and the service account path in the definition module:
 
 ```elixir
 # Specify the Goth module to authenticate in GCP.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ config :waffle,
   storage_dir: "uploads/waffle"
 ```
 
-Also, add the following functions to your definition module:
+In order to be compatible with newer Goth versions, add the following functions
+to your definition module:
 
 ```elixir
 # Specify the Goth module to authenticate in GCP.

--- a/lib/waffle/storage/google/cloud_storage.ex
+++ b/lib/waffle/storage/google/cloud_storage.ex
@@ -61,7 +61,7 @@ defmodule Waffle.Storage.Google.CloudStorage do
   """
   @spec url(Types.definition, Types.version, Types.meta, Keyword.t) :: String.t
   def url(definition, version, meta, opts \\ []) do
-    signer = Util.option(opts, :url_builder, Waffle.Storage.Google.UrlV2)
+    signer = Util.option(opts, :url_builder, Waffle.Storage.Google.UrlV4)
     signer.build(definition, version, meta, opts)
   end
 

--- a/lib/waffle/storage/google/url_v4.ex
+++ b/lib/waffle/storage/google/url_v4.ex
@@ -1,4 +1,4 @@
-defmodule Waffle.Storage.Google.UrlV2 do
+defmodule Waffle.Storage.Google.UrlV4 do
   @moduledoc """
   This is an implementation of the v2 URL signing for Google Cloud Storage. See
   [the Google documentation](https://cloud.google.com/storage/docs/access-control/signed-urls-v2)
@@ -79,18 +79,9 @@ defmodule Waffle.Storage.Google.UrlV2 do
 
   @spec build_signed_url(Types.definition, String.t, Keyword.t) :: String.t
   defp build_signed_url(definition, path, options) do
-    {:ok, client_id} = Goth.Config.get(:client_email)
-
-    expiration = System.os_time(:second) + expiry(options)
-
-    signature = definition
-    |> build_path(path)
-    |> canonical_request(expiration)
-    |> sign_request()
-
-    base_url = build_url(definition, path)
-
-    "#{base_url}?GoogleAccessId=#{client_id}&Expires=#{expiration}&Signature=#{signature}"
+    client = GcsSignedUrl.Client.load_from_file(definition.service_account_path())
+    opts = [expires: @default_expiry] |> Keyword.merge(options)
+    GcsSignedUrl.generate_v4(client, CloudStorage.bucket(definition), path, opts)
   end
 
   @spec build_path(Types.definition, String.t) :: String.t
@@ -111,32 +102,5 @@ defmodule Waffle.Storage.Google.UrlV2 do
     definition
     |> CloudStorage.bucket()
     |> Path.join(path)
-  end
-
-  @spec canonical_request(String.t, pos_integer) :: String.t
-  defp canonical_request(resource, expiration) do
-    "GET\n\n\n#{expiration}\n#{resource}"
-  end
-
-  @spec sign_request(String.t) :: String.t
-  defp sign_request(request) do
-    {:ok, pem_bin} = Goth.Config.get("private_key")
-    [pem_key_data] = :public_key.pem_decode(pem_bin)
-    otp_release = System.otp_release() |> String.to_integer()
-
-    rsa_key =
-      case otp_release do
-        n when n >= 21 ->
-          :public_key.pem_entry_decode(pem_key_data)
-
-        _ ->
-          pem_key = :public_key.pem_entry_decode(pem_key_data)
-          :public_key.der_decode(:RSAPrivateKey, elem(pem_key, 3))
-      end
-
-    request
-    |> :public_key.sign(:sha256, rsa_key)
-    |> Base.encode64()
-    |> URI.encode_www_form()
   end
 end

--- a/lib/waffle/storage/google/util.ex
+++ b/lib/waffle/storage/google/util.ex
@@ -3,12 +3,6 @@ defmodule Waffle.Storage.Google.Util do
   A collection of utility functions.
   """
 
-  alias GoogleApi.Gax.{Request, Response}
-  alias GoogleApi.Storage.V1.Connection
-  alias GoogleApi.Storage.V1.Model.Object
-
-  @library_version Mix.Project.config() |> Keyword.get(:version, "")
-
   @doc """
   Accepts four forms of variables:
 

--- a/mix.exs
+++ b/mix.exs
@@ -39,6 +39,7 @@ defmodule Waffle.Storage.Google.CloudStorage.MixProject do
     [
       {:waffle, "~> 1.1"},
       {:goth, "~> 1.1"},
+      {:gcs_signed_url, "~> 0.4"},
       {:google_api_storage, "~> 0.14"},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
     ]


### PR DESCRIPTION
Add support for new goth versions.

A couple of functions need to be added to the Waffle.Definition module:

```elixir
  # Specify the Goth module to authenticate in GCP.
  def goth_module do
    MyApp.Goth.Storage
  end

  # Defines the service account file to be used to sign the urls.
  def service_account_path do
    Application.fetch_env!(:my_app, :gcp_storage)
    |> Keyword.get(:service_account_path)
  end
```